### PR TITLE
enforce cscli list limits and add metrics UI

### DIFF
--- a/internal/api/handlers/dashboard.go
+++ b/internal/api/handlers/dashboard.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"crowdsec-manager/internal/cache"
 	"crowdsec-manager/internal/config"
+	"crowdsec-manager/internal/constants"
 	"crowdsec-manager/internal/database"
 	"crowdsec-manager/internal/docker"
 	"crowdsec-manager/internal/logger"
@@ -45,9 +47,9 @@ func GetDecisions(dockerClient *docker.Client, cfg *config.Config, ttlCache ...*
 
 		logger.Info("Getting CrowdSec decisions via cscli")
 
-		output, err := dockerClient.ExecCommand(cfg.CrowdsecContainerName, []string{
-			"cscli", "decisions", "list", "-o", "json",
-		})
+		limit := config.EffectiveLimit(cfg.DecisionListLimit, constants.MaxListLimit)
+		cmd := []string{"cscli", "decisions", "list", "-o", "json", "--limit", strconv.Itoa(limit)}
+		output, err := dockerClient.ExecCommand(cfg.CrowdsecContainerName, cmd)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, models.Response{
 				Success: false,

--- a/internal/api/handlers/dashboard_analysis.go
+++ b/internal/api/handlers/dashboard_analysis.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"crowdsec-manager/internal/cache"
 	"crowdsec-manager/internal/config"
+	"crowdsec-manager/internal/constants"
 	"crowdsec-manager/internal/docker"
 	"crowdsec-manager/internal/logger"
 	"crowdsec-manager/internal/models"
@@ -22,7 +24,8 @@ func GetDecisionsAnalysis(dockerClient *docker.Client, cfg *config.Config) gin.H
 		dockerClient = resolveDockerClient(c, dockerClient)
 		logger.Info("Getting CrowdSec decisions analysis via cscli")
 
-		cmd := []string{"cscli", "decisions", "list", "-o", "json"}
+		limit := config.EffectiveLimit(cfg.DecisionListLimit, constants.MaxListLimit)
+		cmd := []string{"cscli", "decisions", "list", "-o", "json", "--limit", strconv.Itoa(limit)}
 
 		// Add filters based on query parameters
 		if v := c.Query("ip"); v != "" {
@@ -165,7 +168,8 @@ func GetAlertsAnalysis(dockerClient *docker.Client, cfg *config.Config, ttlCache
 		if v := c.Query("id"); v != "" {
 			cmd = []string{"cscli", "alerts", "inspect", v, "-o", "json"}
 		} else {
-			cmd = []string{"cscli", "alerts", "list", "-o", "json"}
+			alertLimit := config.EffectiveLimit(cfg.AlertListLimit, constants.MaxListLimit)
+			cmd = []string{"cscli", "alerts", "list", "-o", "json", "--limit", strconv.Itoa(alertLimit)}
 
 			// Add filters based on query parameters
 			if v := c.Query("ip"); v != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,13 +35,13 @@ type Config struct {
 	CrowdSecAcquisFile   string
 
 	// CrowdSec container-internal paths and URLs
-	CrowdSecWhitelistPath      string
-	CrowdSecProfilesPath       string
-	CrowdSecNotificationsDir   string
-	CrowdSecScenariosDir       string
-	CrowdSecMetricsURL         string
-	CrowdSecConsoleURL         string
-	CrowdSecCTIURLPattern      string
+	CrowdSecWhitelistPath    string
+	CrowdSecProfilesPath     string
+	CrowdSecNotificationsDir string
+	CrowdSecScenariosDir     string
+	CrowdSecMetricsURL       string
+	CrowdSecConsoleURL       string
+	CrowdSecCTIURLPattern    string
 
 	// Traefik container-internal paths
 	TraefikCaptchaHTMLPath     string
@@ -60,13 +60,16 @@ type Config struct {
 	GerbilContainerName   string
 	TraefikContainerName  string
 
-
 	// Services
 	Services             []string
 	ServicesWithCrowdsec []string
 	IncludeCrowdsec      bool
 	IncludePangolin      bool
 	IncludeGerbil        bool
+
+	// CrowdSec list limits (0 = unlimited)
+	DecisionListLimit int
+	AlertListLimit    int
 
 	// NATS Messaging (optional)
 	NatsURL     string
@@ -83,37 +86,37 @@ type Config struct {
 // It also creates required directories and dynamically builds service lists from compose file
 func Load() (*Config, error) {
 	cfg := &Config{
-		Port:                  getEnvAsInt("PORT", 8080),
-		Environment:           getEnv("ENVIRONMENT", "development"),
-		LogLevel:              getEnv("LOG_LEVEL", "info"),
-		LogFile:               getEnv("LOG_FILE", "./logs/crowdsec-manager.log"),
-		DockerHost:            getEnv("DOCKER_HOST", ""),
-		DockerHosts:           getEnv("DOCKER_HOSTS", ""),
-		ComposeFile:           getEnv("COMPOSE_FILE", "./docker-compose.yml"),
-		PangolinDir:           getEnv("PANGOLIN_DIR", "."),
-		ConfigDir:             getEnv("CONFIG_DIR", "./config"),
-		DatabasePath:          getEnv("DATABASE_PATH", "./data/settings.db"),
-		TraefikDynamicConfig:  getEnv("TRAEFIK_DYNAMIC_CONFIG", "/etc/traefik/dynamic_config.yml"),
-		TraefikStaticConfig:   getEnv("TRAEFIK_STATIC_CONFIG", "/etc/traefik/traefik_config.yml"),
-		TraefikAccessLog:      getEnv("TRAEFIK_ACCESS_LOG", "/var/log/traefik/access.log"),
-		TraefikErrorLog:       getEnv("TRAEFIK_ERROR_LOG", "/var/log/traefik/traefik.log"),
-		CrowdSecAcquisFile:     getEnv("CROWDSEC_ACQUIS_FILE", "/etc/crowdsec/acquis.yaml"),
-		CrowdSecWhitelistPath:      getEnv("CROWDSEC_WHITELIST_PATH", "/etc/crowdsec/parsers/s02-enrich/mywhitelists.yaml"),
-		CrowdSecProfilesPath:       getEnv("CROWDSEC_PROFILES_PATH", "/etc/crowdsec/profiles.yaml"),
-		CrowdSecNotificationsDir:   getEnv("CROWDSEC_NOTIFICATIONS_DIR", "/etc/crowdsec/notifications"),
-		CrowdSecScenariosDir:       getEnv("CROWDSEC_SCENARIOS_DIR", "/etc/crowdsec/scenarios"),
-		CrowdSecMetricsURL:         getEnv("CROWDSEC_METRICS_URL", "http://localhost:6060/metrics"),
-		CrowdSecConsoleURL:         getEnv("CROWDSEC_CONSOLE_URL", "https://app.crowdsec.net/"),
-		CrowdSecCTIURLPattern:      getEnv("CROWDSEC_CTI_URL_PATTERN", "https://app.crowdsec.net/cti/{{.Value}}"),
-		TraefikCaptchaHTMLPath:     getEnv("TRAEFIK_CAPTCHA_HTML_PATH", "/etc/traefik/conf/captcha.html"),
-		TraefikCaptchaEnvPath:      getEnv("TRAEFIK_CAPTCHA_ENV_PATH", "/etc/traefik/captcha.env"),
+		Port:                     getEnvAsInt("PORT", 8080),
+		Environment:              getEnv("ENVIRONMENT", "development"),
+		LogLevel:                 getEnv("LOG_LEVEL", "info"),
+		LogFile:                  getEnv("LOG_FILE", "./logs/crowdsec-manager.log"),
+		DockerHost:               getEnv("DOCKER_HOST", ""),
+		DockerHosts:              getEnv("DOCKER_HOSTS", ""),
+		ComposeFile:              getEnv("COMPOSE_FILE", "./docker-compose.yml"),
+		PangolinDir:              getEnv("PANGOLIN_DIR", "."),
+		ConfigDir:                getEnv("CONFIG_DIR", "./config"),
+		DatabasePath:             getEnv("DATABASE_PATH", "./data/settings.db"),
+		TraefikDynamicConfig:     getEnv("TRAEFIK_DYNAMIC_CONFIG", "/etc/traefik/dynamic_config.yml"),
+		TraefikStaticConfig:      getEnv("TRAEFIK_STATIC_CONFIG", "/etc/traefik/traefik_config.yml"),
+		TraefikAccessLog:         getEnv("TRAEFIK_ACCESS_LOG", "/var/log/traefik/access.log"),
+		TraefikErrorLog:          getEnv("TRAEFIK_ERROR_LOG", "/var/log/traefik/traefik.log"),
+		CrowdSecAcquisFile:       getEnv("CROWDSEC_ACQUIS_FILE", "/etc/crowdsec/acquis.yaml"),
+		CrowdSecWhitelistPath:    getEnv("CROWDSEC_WHITELIST_PATH", "/etc/crowdsec/parsers/s02-enrich/mywhitelists.yaml"),
+		CrowdSecProfilesPath:     getEnv("CROWDSEC_PROFILES_PATH", "/etc/crowdsec/profiles.yaml"),
+		CrowdSecNotificationsDir: getEnv("CROWDSEC_NOTIFICATIONS_DIR", "/etc/crowdsec/notifications"),
+		CrowdSecScenariosDir:     getEnv("CROWDSEC_SCENARIOS_DIR", "/etc/crowdsec/scenarios"),
+		CrowdSecMetricsURL:       getEnv("CROWDSEC_METRICS_URL", "http://localhost:6060/metrics"),
+		CrowdSecConsoleURL:       getEnv("CROWDSEC_CONSOLE_URL", "https://app.crowdsec.net/"),
+		CrowdSecCTIURLPattern:    getEnv("CROWDSEC_CTI_URL_PATTERN", "https://app.crowdsec.net/cti/{{.Value}}"),
+		TraefikCaptchaHTMLPath:   getEnv("TRAEFIK_CAPTCHA_HTML_PATH", "/etc/traefik/conf/captcha.html"),
+		TraefikCaptchaEnvPath:    getEnv("TRAEFIK_CAPTCHA_ENV_PATH", "/etc/traefik/captcha.env"),
 		TraefikDynamicConfigSearch: []string{
 			"/etc/traefik/config/dynamic_config.yml",
 			"/etc/traefik/dynamic_config.yaml",
 			"/etc/traefik/config/dynamic_config.yaml",
 		},
-		CaptchaGracePeriod:         getEnvAsInt("CAPTCHA_GRACE_PERIOD", 1800),
-		BackupDir:              getEnv("BACKUP_DIR", "./backups"),
+		CaptchaGracePeriod:    getEnvAsInt("CAPTCHA_GRACE_PERIOD", 1800),
+		BackupDir:             getEnv("BACKUP_DIR", "./backups"),
 		RetentionDays:         getEnvAsInt("RETENTION_DAYS", 60),
 		BackupItems:           []string{"docker-compose.yml", "config"},
 		CrowdsecContainerName: getEnv("CROWDSEC_CONTAINER_NAME", "crowdsec"),
@@ -123,6 +126,8 @@ func Load() (*Config, error) {
 		IncludeCrowdsec:       getEnvAsBool("INCLUDE_CROWDSEC", true),
 		IncludePangolin:       getEnvAsBool("INCLUDE_PANGOLIN", true),
 		IncludeGerbil:         getEnvAsBool("INCLUDE_GERBIL", true),
+		DecisionListLimit:     getEnvAsInt("DECISION_LIST_LIMIT", 200),
+		AlertListLimit:        getEnvAsInt("ALERT_LIST_LIMIT", 200),
 		NatsURL:               getEnv("NATS_URL", ""),
 		NatsToken:             getEnv("NATS_TOKEN", ""),
 		NatsEnabled:           getEnvAsBool("NATS_ENABLED", false),
@@ -210,6 +215,16 @@ func (c *Config) GetServices() []string {
 		return c.ServicesWithCrowdsec
 	}
 	return c.Services
+}
+
+// EffectiveLimit returns the effective list limit, applying the hard safety cap.
+// If the configured limit is 0 (unlimited), it returns maxLimit.
+// If the configured limit exceeds maxLimit, it returns maxLimit.
+func EffectiveLimit(configured, maxLimit int) int {
+	if configured <= 0 || configured > maxLimit {
+		return maxLimit
+	}
+	return configured
 }
 
 // getEnv retrieves an environment variable or returns the default value if not set

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -30,6 +30,16 @@ const CrowdSecConfigSubdir = "crowdsec"
 // DefaultWebSocketBufferSize is the default buffer size for WebSocket read/write operations
 const DefaultWebSocketBufferSize = 4096
 
+// MaxListLimit is the hard safety cap for cscli list commands.
+// Even when the user sets limit=0 (unlimited), we enforce this cap to prevent
+// memory exhaustion from very large result sets (e.g. 10,000+ decisions/alerts).
+// Matches CrowdSec's default DB retention of 5,000 items.
+const MaxListLimit = 5000
+
+// ExecCommandTimeout is the timeout for cscli commands executed inside containers.
+// Prevents hanging if cscli takes too long on large datasets.
+const ExecCommandTimeout = 60 * time.Second
+
 // ExternalHTTPTimeout is the timeout for outbound HTTP requests (IP lookups, etc.)
 const ExternalHTTPTimeout = 10 * time.Second
 

--- a/web/src/pages/Metrics.tsx
+++ b/web/src/pages/Metrics.tsx
@@ -2,17 +2,163 @@ import { useQuery } from '@tanstack/react-query'
 import { crowdsecAPI } from '@/lib/api/crowdsec'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { RefreshCw, BarChart3 } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { RefreshCw, BarChart3, Activity, Shield, Eye, Database, Server, FileText } from 'lucide-react'
 import { PageHeader, PageLoader, QueryError } from '@/components/common'
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table'
+import {
+  Tabs, TabsContent, TabsList, TabsTrigger,
+} from '@/components/ui/tabs'
+
+// Metrics data returned by `cscli metrics -o json`
+type MetricsData = Record<string, unknown>
+
+/** Flatten a nested metrics section into displayable rows */
+function flattenMetricsSection(section: unknown): { key: string; values: Record<string, string | number> }[] {
+  if (!section || typeof section !== 'object') return []
+  const rows: { key: string; values: Record<string, string | number> }[] = []
+  for (const [key, val] of Object.entries(section as Record<string, unknown>)) {
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      // Could be a simple {hits: 10, parsed: 10} or nested further
+      const flat = flattenToKV(val as Record<string, unknown>)
+      rows.push({ key, values: flat })
+    } else {
+      rows.push({ key, values: { value: String(val ?? '') } })
+    }
+  }
+  return rows
+}
+
+/** Recursively flatten nested objects into dot-separated keys */
+function flattenToKV(obj: Record<string, unknown>, prefix = ''): Record<string, string | number> {
+  const result: Record<string, string | number> = {}
+  for (const [k, v] of Object.entries(obj)) {
+    const fullKey = prefix ? `${prefix}.${k}` : k
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      Object.assign(result, flattenToKV(v as Record<string, unknown>, fullKey))
+    } else if (typeof v === 'number') {
+      result[fullKey] = v
+    } else {
+      result[fullKey] = String(v ?? '')
+    }
+  }
+  return result
+}
+
+/** Collect all unique value-column names from a set of rows */
+function collectColumns(rows: { values: Record<string, string | number> }[]): string[] {
+  const cols = new Set<string>()
+  for (const row of rows) {
+    for (const k of Object.keys(row.values)) cols.add(k)
+  }
+  return Array.from(cols).sort()
+}
+
+function formatNumber(v: string | number): string {
+  if (typeof v === 'number') return v.toLocaleString()
+  return v
+}
+
+const SECTION_META: Record<string, { label: string; icon: React.ReactNode }> = {
+  acquisition: { label: 'Acquisition', icon: <FileText className="h-4 w-4" /> },
+  parsers: { label: 'Parsers', icon: <Database className="h-4 w-4" /> },
+  scenarios: { label: 'Scenarios', icon: <Activity className="h-4 w-4" /> },
+  bouncers: { label: 'Bouncers', icon: <Shield className="h-4 w-4" /> },
+  decisions: { label: 'Decisions', icon: <Shield className="h-4 w-4" /> },
+  alerts: { label: 'Alerts', icon: <Activity className="h-4 w-4" /> },
+  lapi: { label: 'LAPI', icon: <Server className="h-4 w-4" /> },
+  'lapi-bouncer': { label: 'LAPI Bouncer', icon: <Server className="h-4 w-4" /> },
+  'lapi-machine': { label: 'LAPI Machine', icon: <Server className="h-4 w-4" /> },
+  'lapi-decisions': { label: 'LAPI Decisions', icon: <Server className="h-4 w-4" /> },
+  whitelists: { label: 'Whitelists', icon: <Eye className="h-4 w-4" /> },
+  'appsec-engine': { label: 'AppSec Engine', icon: <Shield className="h-4 w-4" /> },
+  'appsec-rule': { label: 'AppSec Rules', icon: <Shield className="h-4 w-4" /> },
+  stash: { label: 'Stash', icon: <Database className="h-4 w-4" /> },
+}
+
+/** Render a single metrics section as a table */
+function MetricsSection({ name, data }: { name: string; data: unknown }) {
+  const rows = flattenMetricsSection(data)
+  if (rows.length === 0) return null
+  const columns = collectColumns(rows)
+
+  const meta = SECTION_META[name] ?? { label: name, icon: <BarChart3 className="h-4 w-4" /> }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          {meta.icon}
+          {meta.label}
+          <Badge variant="secondary" className="text-xs font-normal">{rows.length}</Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="rounded-md border overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="min-w-[200px]">Name</TableHead>
+                {columns.map(col => (
+                  <TableHead key={col} className="text-right whitespace-nowrap">{col}</TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map(row => (
+                <TableRow key={row.key}>
+                  <TableCell className="font-mono text-sm">{row.key}</TableCell>
+                  {columns.map(col => (
+                    <TableCell key={col} className="text-right font-mono text-sm tabular-nums">
+                      {row.values[col] !== undefined ? formatNumber(row.values[col]) : '-'}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+// Preferred ordering of tabs
+const SECTION_ORDER = [
+  'acquisition', 'parsers', 'scenarios', 'bouncers', 'decisions',
+  'alerts', 'lapi', 'lapi-bouncer', 'lapi-machine', 'lapi-decisions',
+  'whitelists', 'appsec-engine', 'appsec-rule', 'stash',
+]
 
 export default function Metrics() {
   const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['crowdsec-metrics'],
     queryFn: async () => {
       const response = await crowdsecAPI.getMetrics()
-      return (response.data.data ?? null) as { metrics: string } | null
+      return (response.data.data ?? null) as MetricsData | null
     },
     refetchInterval: 30000,
+  })
+
+  // Sort sections: known order first, then any extras
+  const sections = data
+    ? Object.keys(data).sort((a, b) => {
+        const ai = SECTION_ORDER.indexOf(a)
+        const bi = SECTION_ORDER.indexOf(b)
+        if (ai === -1 && bi === -1) return a.localeCompare(b)
+        if (ai === -1) return 1
+        if (bi === -1) return -1
+        return ai - bi
+      })
+    : []
+
+  // Filter out empty sections
+  const nonEmptySections = sections.filter(s => {
+    const val = data![s]
+    if (!val || typeof val !== 'object') return false
+    return Object.keys(val as Record<string, unknown>).length > 0
   })
 
   return (
@@ -50,10 +196,24 @@ export default function Metrics() {
         <CardContent>
           {isLoading ? (
             <PageLoader message="Loading metrics..." />
-          ) : data?.metrics ? (
-            <pre className="p-4 bg-muted rounded-lg text-sm overflow-auto whitespace-pre-wrap font-mono max-h-[70vh]">
-              {data.metrics}
-            </pre>
+          ) : nonEmptySections.length > 0 ? (
+            <Tabs defaultValue={nonEmptySections[0]} className="space-y-4">
+              <TabsList className="flex-wrap h-auto gap-1">
+                {nonEmptySections.map(section => {
+                  const meta = SECTION_META[section] ?? { label: section }
+                  return (
+                    <TabsTrigger key={section} value={section} className="text-xs">
+                      {meta.label}
+                    </TabsTrigger>
+                  )
+                })}
+              </TabsList>
+              {nonEmptySections.map(section => (
+                <TabsContent key={section} value={section}>
+                  <MetricsSection name={section} data={data![section]} />
+                </TabsContent>
+              ))}
+            </Tabs>
           ) : (
             <p className="text-muted-foreground text-sm">No metrics data available</p>
           )}


### PR DESCRIPTION
add a hard safety cap for cscli list commands (constants.MaxListLimit) and an ExecCommandTimeout. Introduce DecisionListLimit and AlertListLimit config options (env vars DECISION_LIST_LIMIT, ALERT_LIST_LIMIT) and an EffectiveLimit helper to compute the applied limit. Update dashboard handlers to pass a --limit argument to cscli (use strconv) to prevent huge result sets and potential memory exhaustion. Enhance the Metrics page (web/src/pages/Metrics.tsx) to render structured metrics as tabbed tables with flattening logic and improved UI/ordering.