### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Native iOS and Android app. Supports **Pangolin** (token-based remote access) an
     container_name: crowdsec-manager
     restart: unless-stopped
     ports:
-     -8080:8080
+      - 8080:8080
     environment:
       - PORT=8080
       - ENVIRONMENT=production

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Native iOS and Android app. Supports **Pangolin** (token-based remote access) an
     image: hhftechnology/crowdsec-manager:latest
     container_name: crowdsec-manager
     restart: unless-stopped
+    ports:
+     -8080:8080
     environment:
       - PORT=8080
       - ENVIRONMENT=production


### PR DESCRIPTION
Added the missing 
"ports: 
  - 8080:8080" to the Pangolin Quick Start sample

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Pangolin Quick Start Docker Compose guide to include explicit port mapping configuration, clarifying how to access the service on port 8080.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->